### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "myelin-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alga 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockiato 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 This crate contains the physical engine of
 the simulation, as well as the objects that reside
 within it"""
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Jan Nils Ferner <jan@myelin.ch>",
     "Mathias Fischler <mathias@myelin.ch>",


### PR DESCRIPTION
In this version, `Object` stores `ObjectBehavior` directly as a
reference, enabling a more comfortable usage of the type.