### PR TITLE
Support collision checks in areas defined by any convex polygon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,11 +149,11 @@ dependencies = [
 
 [[package]]
 name = "myelin-engine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alga 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockiato 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "myelin-geometry 2.0.0",
+ "myelin-geometry 2.1.0",
  "nalgebra 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nameof 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ncollide2d 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "myelin-geometry"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "nearly_eq 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT/Apache-2.0"
 keywords = [ "simulation", "2d", "physics" ]
 
 [dependencies]
-myelin-geometry = { path = "../geometry", version = "2.0.0" }
+myelin-geometry = { path = "../geometry", version = "2.1.0" }
 nalgebra = "0.17"
 ncollide2d = "0.18"
 serde = "1.0"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 This crate contains the physical engine of
 the simulation, as well as the objects that reside
 within it"""
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "Jan Nils Ferner <jan@myelin.ch>",
     "Mathias Fischler <mathias@myelin.ch>",

--- a/engine/changelog.md
+++ b/engine/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.0
+
+- Initial release
+
 ## 0.2.0
 
 - Make mocks for `Simulation` more flexible
+
+## 0.2.1
+
+- Add support for intersection tests with arbitrary polygons. [Issue #49](https://github.com/myelin-ai/engine/issues/49)

--- a/engine/src/simulation.rs
+++ b/engine/src/simulation.rs
@@ -266,7 +266,7 @@ mod mocks {
             let (expected_area, return_value) = match self.expect_objects_in_polygon_and_return {
                 ObjectsInAreaExpectation::None => panic!(UNEXPECTED_CALL_ERROR_MESSAGE),
                 ObjectsInAreaExpectation::AtLeastOnce(ref expected_area, ref return_value) => {
-                    (*expected_area, return_value.clone())
+                    (expected_area.clone(), return_value.clone())
                 }
                 ObjectsInAreaExpectation::Sequence(ref expected_calls_and_return_values) => {
                     expected_calls_and_return_values

--- a/engine/src/simulation.rs
+++ b/engine/src/simulation.rs
@@ -41,6 +41,10 @@ pub trait Simulation: Debug {
     /// Returns read-only descriptions for all objects either completely
     /// contained or intersecting with the given area.
     fn objects_in_area(&self, area: Aabb) -> Snapshot<'_>;
+
+    /// Returns read-only descriptions for all objects either completely
+    /// contained or intersecting with the given area.
+    fn objects_in_polygon(&self, area: Polygon) -> Snapshot<'_>;
 }
 
 /// Unique identifier of an Object
@@ -92,12 +96,14 @@ mod mocks {
         expect_add_object_and_return: AddObjectExpectation<ObjectDescription, FullyOwnedObject>,
         expect_set_simulated_timestep: Option<(f64,)>,
         expect_objects_in_area_and_return: ObjectsInAreaExpectation<Aabb, Snapshot<'a>>,
+        expect_objects_in_polygon_and_return: ObjectsInAreaExpectation<Polygon, Snapshot<'a>>,
 
         step_was_called: RefCell<bool>,
         objects_was_called: RefCell<bool>,
         add_object_was_called: RefCell<bool>,
         set_simulated_timestep_was_called: RefCell<bool>,
         objects_in_area_was_called: RefCell<bool>,
+        objects_in_polygon_was_called: RefCell<bool>,
     }
 
     /// A helper tuple with an owned [`ObjectBehavior`], used to assemble an [`Object`] in mocks.
@@ -250,6 +256,34 @@ mod mocks {
 
             return_value.clone()
         }
+
+        fn objects_in_polygon(&self, area: Polygon) -> Snapshot<'_> {
+            *self.objects_in_polygon_was_called.borrow_mut() = true;
+
+            const UNEXPECTED_CALL_ERROR_MESSAGE: &str =
+                "objects_in_polygon() was called unexpectedly";
+
+            let (expected_area, return_value) = match self.expect_objects_in_polygon_and_return {
+                ObjectsInAreaExpectation::None => panic!(UNEXPECTED_CALL_ERROR_MESSAGE),
+                ObjectsInAreaExpectation::AtLeastOnce(ref expected_area, ref return_value) => {
+                    (*expected_area, return_value.clone())
+                }
+                ObjectsInAreaExpectation::Sequence(ref expected_calls_and_return_values) => {
+                    expected_calls_and_return_values
+                        .borrow_mut()
+                        .pop_front()
+                        .expect(UNEXPECTED_CALL_ERROR_MESSAGE)
+                }
+            };
+
+            assert_eq!(
+                expected_area, area,
+                "objects_in_polygon() was called with {:?}, expected {:?}",
+                area, expected_area
+            );
+
+            return_value.clone()
+        }
     }
 
     impl<'a> Drop for SimulationMock<'a> {
@@ -287,6 +321,15 @@ mod mocks {
                 assert!(
                     *self.objects_in_area_was_called.borrow(),
                     "objects_in_area() was not called, but expected"
+                );
+            }
+
+            if let ObjectsInAreaExpectation::AtLeastOnce(..)
+            | ObjectsInAreaExpectation::Sequence(..) = self.expect_objects_in_polygon_and_return
+            {
+                assert!(
+                    *self.objects_in_polygon_was_called.borrow(),
+                    "objects_in_polygon() was not called, but expected"
                 );
             }
         }

--- a/engine/src/simulation/simulation_impl.rs
+++ b/engine/src/simulation/simulation_impl.rs
@@ -915,7 +915,7 @@ mod tests {
             .expect_add_body(partial_eq(expected_physical_body.clone()))
             .returns(returned_handle);
         world
-            .expect_bodies_in_polygon(partial_eq(area))
+            .expect_bodies_in_polygon(partial_eq(area.clone()))
             .returns(vec![returned_handle]);
         world
             .expect_body(partial_eq(returned_handle))

--- a/engine/src/simulation/simulation_impl/world.rs
+++ b/engine/src/simulation/simulation_impl/world.rs
@@ -64,9 +64,11 @@ pub trait World: Debug {
 
     /// Returns all bodies either completely contained or intersecting
     /// with the area.
-    ///
-    /// [`Aabb`]: ./struct.Aabb.html
     fn bodies_in_area(&self, area: Aabb) -> Vec<BodyHandle>;
+
+    /// Returns all bodies either completely contained or intersecting
+    /// with the area.
+    fn bodies_in_polygon(&self, area: Polygon) -> Vec<BodyHandle>;
 }
 
 /// The pure physical representation of an object

--- a/engine/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/engine/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -312,7 +312,7 @@ impl World for NphysicsWorld {
                 let body = self
                     .body(body_handle)
                     .expect("Internal error: Nphysics returned invalid handle");
-                area.aabb().intersects(body.shape.aabb())
+                area.intersects(body.shape)
             })
             .collect()
     }

--- a/engine/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/engine/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -312,7 +312,7 @@ impl World for NphysicsWorld {
                 let body = self
                     .body(body_handle)
                     .expect("Internal error: Nphysics returned invalid handle");
-                area.intersects(body.shape)
+                area.aabb().intersects(body.shape.aabb())
             })
             .collect()
     }

--- a/engine/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/engine/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -312,7 +312,7 @@ impl World for NphysicsWorld {
                 let body = self
                     .body(body_handle)
                     .expect("Internal error: Nphysics returned invalid handle");
-                area.intersects(body.shape)
+                area.intersects(&body.shape)
             })
             .collect()
     }

--- a/engine/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/engine/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -623,7 +623,7 @@ mod tests {
 
         world.step();
 
-        const TRIANGLE_SIDE_LENGTH: f64 = 22.0;
+        const TRIANGLE_SIDE_LENGTH: f64 = 23.0;
         let area = PolygonBuilder::default()
             .vertex(TRIANGLE_SIDE_LENGTH, 0.0)
             .vertex(TRIANGLE_SIDE_LENGTH, TRIANGLE_SIDE_LENGTH)

--- a/engine/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/engine/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn bodies_in_polygon_returns_body_in_area() {
-        let rotation_translator = rotation_translator_for_adding_body();
+        let rotation_translator = rotation_translator_for_adding_and_reading_body();
 
         let mut world = NphysicsWorld::with_timestep(DEFAULT_TIMESTEP, box rotation_translator);
         let expected_body = movable_body();
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn bodies_in_polygon_does_not_return_out_of_range_bodies() {
-        let rotation_translator = rotation_translator_for_adding_body();
+        let rotation_translator = rotation_translator_for_adding_and_reading_body();
 
         let mut world = NphysicsWorld::with_timestep(DEFAULT_TIMESTEP, box rotation_translator);
         let body = movable_body();

--- a/engine/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/engine/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -299,6 +299,23 @@ impl World for NphysicsWorld {
             .map(|collision| to_body_handle(collision.handle()))
             .collect()
     }
+
+    fn bodies_in_polygon(&self, area: Polygon) -> Vec<BodyHandle> {
+        let collision_groups = CollisionGroups::new();
+        let area_aabb = area.aabb();
+
+        self.physics_world
+            .collider_world()
+            .interferences_with_aabb(&to_ncollide_aabb(area_aabb), &collision_groups)
+            .map(|collision| to_body_handle(collision.handle()))
+            .filter(|&body_handle| {
+                let body = self
+                    .body(body_handle)
+                    .expect("Internal error: Nphysics returned invalid handle");
+                area.intersects(body.shape)
+            })
+            .collect()
+    }
 }
 
 fn to_body_handle(collider_handle: ColliderHandle) -> BodyHandle {
@@ -551,10 +568,10 @@ mod tests {
 
         world.step();
 
-        assert_eq!(
-            vec![handle],
-            world.bodies_in_area(Aabb::try_new((-100.0, -100.0), (100.0, 100.0)).unwrap())
-        );
+        let area = Aabb::try_new((-100.0, -100.0), (100.0, 100.0)).unwrap();
+        let bodies = world.bodies_in_area(area);
+
+        assert_eq!(vec![handle], bodies);
     }
 
     #[test]
@@ -562,15 +579,57 @@ mod tests {
         let rotation_translator = rotation_translator_for_adding_body();
 
         let mut world = NphysicsWorld::with_timestep(DEFAULT_TIMESTEP, box rotation_translator);
-        let expected_body = movable_body();
-        let _handle = world.add_body(expected_body.clone());
+        let body = movable_body();
+        let _handle = world.add_body(body);
 
         world.step();
 
-        assert_eq!(
-            Vec::<BodyHandle>::new(),
-            world.bodies_in_area(Aabb::try_new((20.0, 20.0), (30.0, 40.0)).unwrap())
-        );
+        let area = Aabb::try_new((20.0, 20.0), (30.0, 40.0)).unwrap();
+        let bodies = world.bodies_in_area(area);
+
+        assert!(bodies.is_empty());
+    }
+
+    #[test]
+    fn bodies_in_polygon_returns_body_in_area() {
+        let rotation_translator = rotation_translator_for_adding_body();
+
+        let mut world = NphysicsWorld::with_timestep(DEFAULT_TIMESTEP, box rotation_translator);
+        let expected_body = movable_body();
+        let handle = world.add_body(expected_body);
+
+        world.step();
+
+        let area = PolygonBuilder::default()
+            .vertex(-100.0, -100.0)
+            .vertex(100.0, -100.0)
+            .vertex(0.0, 100.0)
+            .build()
+            .unwrap();
+        let bodies = world.bodies_in_polygon(area);
+
+        assert_eq!(vec![handle], bodies);
+    }
+
+    #[test]
+    fn bodies_in_polygon_does_not_return_out_of_range_bodies() {
+        let rotation_translator = rotation_translator_for_adding_body();
+
+        let mut world = NphysicsWorld::with_timestep(DEFAULT_TIMESTEP, box rotation_translator);
+        let body = movable_body();
+        let _handle = world.add_body(body);
+
+        world.step();
+
+        let area = PolygonBuilder::default()
+            .vertex(5.0, -10.0)
+            .vertex(30.0, -10.0)
+            .vertex(20.0, 5.0)
+            .build()
+            .unwrap();
+        let bodies = world.bodies_in_polygon(area);
+
+        assert!(bodies.is_empty())
     }
 
     #[test]

--- a/geometry/Cargo.toml
+++ b/geometry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "myelin-geometry"
 description = "Basic linear and vector geometry for two-dimensional Euclidean geometry"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     "Jan Nils Ferner <jan@myelin.ch>",
     "Mathias Fischler <mathias@myelin.ch>",

--- a/geometry/changelog.md
+++ b/geometry/changelog.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 1.0
+
+- Initial release
+
+## 2.0
+
+- Sanitize Aabbs by replacing `fn new(...) -> Self` with `fn try_new(...) -> Result<Self>`
+
+## 0.2.1
+
+- Add support for intersection tests between `Polygon`s.
+- Unify the `intersects` methods of `Polygon` and `Aabb` under the `Intersects` trait
+- Add some useful functions to `Vector`.
+    - Support calculating the `normal` (i.e. perpendicular) vector
+    - Support calculating the `magnitude`
+    - Support calculating the `unit` vector

--- a/geometry/src/aabb.rs
+++ b/geometry/src/aabb.rs
@@ -83,7 +83,7 @@ impl Intersects for Aabb {
         let y_overlaps =
             self.upper_left.y <= other.lower_right.y && self.lower_right.y >= other.upper_left.y;
 
-        x_overlaps || y_overlaps
+        x_overlaps && y_overlaps
     }
 }
 

--- a/geometry/src/aabb.rs
+++ b/geometry/src/aabb.rs
@@ -169,7 +169,7 @@ mod tests {
     fn does_not_intersect_when_appart() {
         let first_aabb = Aabb::try_new((0.0, 0.0), (10.0, 10.0)).unwrap();
         let second_aabb = Aabb::try_new((20.0, 0.0), (21.0, 20.0)).unwrap();
-        assert!(first_aabb.intersects(&second_aabb));
-        assert!(second_aabb.intersects(&first_aabb));
+        assert!(!first_aabb.intersects(&second_aabb));
+        assert!(!second_aabb.intersects(&first_aabb));
     }
 }

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -693,7 +693,7 @@ mod tests {
         ])
         .unwrap();
         let second_polygon = Polygon::try_new(vec![
-            Point { x: -6.0, y: -20.0 },
+            Point { x: -8.0, y: -20.0 },
             Point { x: -3.0, y: -20.0 },
             Point { x: -3.0, y: -3.0 },
         ])

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -195,7 +195,7 @@ impl Intersects for Polygon {
 
                 // If both bounds are outside the other polygon's projection, we are
                 // able to draw a separating axis between them
-                own_min.min(other_min) <= own_max.max(other_max)
+                own_min.max(other_min) <= own_max.min(other_max)
             })
     }
 }

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -739,7 +739,7 @@ mod tests {
             Point { x: 21.0, y: 20.0 },
         ])
         .unwrap();
-        assert!(first_polygon.intersects(&second_polygon));
-        assert!(second_polygon.intersects(&first_polygon));
+        assert!(!first_polygon.intersects(&second_polygon));
+        assert!(!second_polygon.intersects(&first_polygon));
     }
 }

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -114,6 +114,11 @@ impl Polygon {
             .all(|side| side == reference_side || side == Side::OnTheLine)
     }
 
+    /// Checks if another polygon touches or is contained in this polygon
+    pub fn intersects(other: Polygon) -> bool {
+        unimplemented!()
+    }
+
     /// Returns an [`Aabb`] which fully contains this polygon.
     ///
     /// # Panics

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -115,7 +115,7 @@ impl Polygon {
     }
 
     /// Checks if another polygon touches or is contained in this polygon
-    pub fn intersects(other: Polygon) -> bool {
+    pub fn intersects(&self, other: Polygon) -> bool {
         unimplemented!()
     }
 

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -115,11 +115,6 @@ impl Polygon {
             .all(|side| side == reference_side || side == Side::OnTheLine)
     }
 
-    /// Checks if another polygon touches or is contained in this polygon
-    pub fn intersects(&self, other: Polygon) -> bool {
-        unimplemented!()
-    }
-
     /// Returns an [`Aabb`] which fully contains this polygon.
     ///
     /// # Panics

--- a/geometry/src/polygon.rs
+++ b/geometry/src/polygon.rs
@@ -178,8 +178,7 @@ impl Intersects for Polygon {
         // between two polygons (i.e. separating them), they are not intersecting
 
         // Take all edges
-        !self
-            .edges()
+        self.edges()
             .chain(other.edges())
             // If we can draw a perpendicular (i.e. normal) between them,
             // the polygons are separate
@@ -188,19 +187,15 @@ impl Intersects for Polygon {
             // If the axis has a magnitude of 1, we don't need to divide
             // the scalar projection by it.
             .map(Vector::unit)
-            .any(|axis| {
+            .all(|axis| {
                 // Take the bounds of the line that is created by projecting all
                 // vertices onto the axis
                 let (own_min, own_max) = self.scalar_project_onto_unit_vector(axis);
                 let (other_min, other_max) = other.scalar_project_onto_unit_vector(axis);
 
-                // Check if the bounds are touching the other polygon's projection
-                let min_is_touching_other_projection = own_min >= other_min || own_min <= other_max;
-                let max_is_touching_other_projection = own_max <= other_max || own_max >= other_min;
-
                 // If both bounds are outside the other polygon's projection, we are
                 // able to draw a separating axis between them
-                !min_is_touching_other_projection && !max_is_touching_other_projection
+                own_min.min(other_min) <= own_max.max(other_max)
             })
     }
 }


### PR DESCRIPTION
Resolves #49 

Note that [ncollide does not support this natively](https://www.ncollide.org/rustdoc/ncollide2d/world/struct.CollisionWorld.html), so under the hood we instead take all objects inside the polygon's AABB and filter them.

Related issue: https://github.com/rustsim/ncollide/issues/267