### PR TITLE
Expose interferences with polygon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 This crate contains the physical engine of
 the simulation, as well as the objects that reside
 within it"""
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jan Nils Ferner <jan@myelin.ch>",
     "Mathias Fischler <mathias@myelin.ch>",

--- a/changelog.md
+++ b/changelog.md
@@ -13,3 +13,7 @@
 - Move `own_description` from the signature of `ObjectBehavior::step` to the new function `WorldInteractor::own_object(&self) -> Object<'_>`
     - This also allows access to an object's own ID
 - Support object retrieval with an ID via `Simulation::object(&self, id: Id) -> Option<Object<'_>>`
+
+## 0.6.0
+- Actually expose the collision checks added in 0.4.1 in `WorldInteractor`
+- Improve performance by using references to `Polygon`s everywhere

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -47,7 +47,7 @@ pub trait Simulation: Debug {
 
     /// Returns read-only descriptions for all objects either completely
     /// contained or intersecting with the given area.
-    fn objects_in_polygon(&self, area: Polygon) -> Snapshot<'_>;
+    fn objects_in_polygon(&self, area: &Polygon) -> Snapshot<'_>;
 }
 
 /// Unique identifier of an Object
@@ -298,7 +298,7 @@ mod mocks {
             return_value.clone()
         }
 
-        fn objects_in_polygon(&self, area: Polygon) -> Snapshot<'_> {
+        fn objects_in_polygon(&self, area: &Polygon) -> Snapshot<'_> {
             *self.objects_in_polygon_was_called.borrow_mut() = true;
 
             const UNEXPECTED_CALL_ERROR_MESSAGE: &str =
@@ -318,9 +318,9 @@ mod mocks {
             };
 
             assert_eq!(
-                expected_area, area,
+                expected_area, *area,
                 "objects_in_polygon() was called with {:?}, expected {:?}",
-                area, expected_area
+                *area, expected_area
             );
 
             return_value.clone()

--- a/src/simulation/simulation_impl.rs
+++ b/src/simulation/simulation_impl.rs
@@ -167,14 +167,6 @@ impl SimulationImpl {
             .to_action_result()
     }
 
-    fn handle_to_object(&self, handle: BodyHandle) -> Option<Object<'_>> {
-        Some(Object {
-            id: handle.0,
-            description: self.handle_to_description(handle)?,
-            behavior: self.handle_to_behavior(handle)?,
-        })
-    }
-
     fn handle_to_behavior(&self, handle: BodyHandle) -> Option<&dyn ObjectBehavior> {
         let ptr = self
             .non_physical_object_data
@@ -264,14 +256,19 @@ impl Simulation for SimulationImpl {
         self.non_physical_object_data
             .keys()
             .map(|&handle| {
-                self.handle_to_object(handle)
+                Simulation::object(self, handle.0)
                     .expect("Handle stored in simulation was not found in world")
             })
             .collect()
     }
 
     fn object(&self, id: Id) -> Option<Object<'_>> {
-        self.handle_to_object(BodyHandle(id))
+        let handle = BodyHandle(id);
+        Some(Object {
+            id: handle.0,
+            description: self.handle_to_description(handle)?,
+            behavior: self.handle_to_behavior(handle)?,
+        })
     }
 
     fn set_simulated_timestep(&mut self, timestep: f64) {
@@ -284,7 +281,7 @@ impl Simulation for SimulationImpl {
             .bodies_in_area(area)
             .into_iter()
             .map(|handle| {
-                self.handle_to_object(handle)
+                Simulation::object(self, handle.0)
                     .expect("Handle stored in simulation was not found in world")
             })
             .collect()
@@ -295,7 +292,7 @@ impl Simulation for SimulationImpl {
             .bodies_in_polygon(area)
             .into_iter()
             .map(|handle| {
-                self.handle_to_object(handle)
+                Simulation::object(self, handle.0)
                     .expect("Handle stored in simulation was not found in world")
             })
             .collect()

--- a/src/simulation/simulation_impl.rs
+++ b/src/simulation/simulation_impl.rs
@@ -290,7 +290,7 @@ impl Simulation for SimulationImpl {
             .collect()
     }
 
-    fn objects_in_polygon(&self, area: Polygon) -> Snapshot<'_> {
+    fn objects_in_polygon(&self, area: &Polygon) -> Snapshot<'_> {
         self.world
             .bodies_in_polygon(area)
             .into_iter()
@@ -305,6 +305,10 @@ impl Simulation for SimulationImpl {
 impl Interactable for SimulationImpl {
     fn objects_in_area(&self, area: Aabb) -> Snapshot<'_> {
         Simulation::objects_in_area(self, area)
+    }
+
+    fn objects_in_polygon(&self, area: &Polygon) -> Snapshot<'_> {
+        Simulation::objects_in_polygon(self, area)
     }
 
     fn elapsed_time_in_update(&self) -> Duration {
@@ -327,7 +331,7 @@ mod tests {
     use crate::object_builder::ObjectBuilder;
     use crate::simulation::simulation_impl::world::WorldMock;
     use crate::world_interactor::{Interactable, WorldInteractor, WorldInteractorMock};
-    use mockiato::partial_eq;
+    use mockiato::{partial_eq, partial_eq_owned};
     use myelin_geometry::PolygonBuilder;
     use std::thread::sleep;
     use std::time::Instant;
@@ -992,7 +996,7 @@ mod tests {
             .expect_add_body(partial_eq(expected_physical_body.clone()))
             .returns(returned_handle);
         world
-            .expect_bodies_in_polygon(partial_eq(area.clone()))
+            .expect_bodies_in_polygon(partial_eq_owned(area.clone()))
             .returns(vec![returned_handle]);
         world
             .expect_body(partial_eq(returned_handle))
@@ -1010,7 +1014,7 @@ mod tests {
         let object_behavior = box ObjectBehaviorMock::new();
         simulation.add_object(object_description.clone(), object_behavior);
 
-        let objects_in_polygon = Simulation::objects_in_polygon(&simulation, area);
+        let objects_in_polygon = Simulation::objects_in_polygon(&simulation, &area);
         assert_eq!(1, objects_in_polygon.len());
         assert_eq!(returned_handle.0, objects_in_polygon[0].id);
         assert_eq!(object_description, objects_in_polygon[0].description);

--- a/src/simulation/simulation_impl/world.rs
+++ b/src/simulation/simulation_impl/world.rs
@@ -68,7 +68,7 @@ pub trait World: Debug {
 
     /// Returns all bodies either completely contained or intersecting
     /// with the area.
-    fn bodies_in_polygon(&self, area: Polygon) -> Vec<BodyHandle>;
+    fn bodies_in_polygon(&self, area: &Polygon) -> Vec<BodyHandle>;
 }
 
 /// The pure physical representation of an object

--- a/src/simulation/simulation_impl/world/nphysics_world.rs
+++ b/src/simulation/simulation_impl/world/nphysics_world.rs
@@ -300,7 +300,7 @@ impl World for NphysicsWorld {
             .collect()
     }
 
-    fn bodies_in_polygon(&self, area: Polygon) -> Vec<BodyHandle> {
+    fn bodies_in_polygon(&self, area: &Polygon) -> Vec<BodyHandle> {
         let area_aabb = area.aabb();
 
         self.bodies_in_area(area_aabb)
@@ -608,7 +608,7 @@ mod tests {
             .vertex(0.0, 100.0)
             .build()
             .unwrap();
-        let bodies = world.bodies_in_polygon(area);
+        let bodies = world.bodies_in_polygon(&area);
 
         assert_eq!(vec![handle], bodies);
     }
@@ -630,7 +630,7 @@ mod tests {
             .vertex(0.0, TRIANGLE_SIDE_LENGTH)
             .build()
             .unwrap();
-        let bodies = world.bodies_in_polygon(area);
+        let bodies = world.bodies_in_polygon(&area);
 
         assert!(bodies.is_empty())
     }

--- a/src/world_interactor.rs
+++ b/src/world_interactor.rs
@@ -19,13 +19,17 @@ use mockiato::mockable;
 /// [`ObjectBehavior`]: ./trait.ObjectBehavior.html
 #[cfg_attr(any(test, feature = "use-mocks"), mockable)]
 pub trait WorldInteractor: Debug {
-    /// Scans for objects in the area defined by an [`Aabb`].
+    /// Scans for objects in the area defined by an `Aabb`.
     ///
     /// Returns all objects either completely contained or intersecting
-    /// with the area.
-    ///
-    /// [`Aabb`]: ./struct.Aabb.html
+    /// within the area.
     fn find_objects_in_area(&self, area: Aabb) -> Snapshot<'_>;
+
+    /// Scans for objects in the area defined by a `Polygon`.
+    ///
+    /// Returns all objects either completely contained or intersecting
+    /// within the area.
+    fn find_objects_in_polygon(&self, area: &Polygon) -> Snapshot<'_>;
 
     /// Returns the amount of time that passed since the last call
     /// to the `step` function of [`Simulation`]

--- a/src/world_interactor/interactable.rs
+++ b/src/world_interactor/interactable.rs
@@ -13,6 +13,10 @@ pub trait Interactable: Debug {
     /// contained or intersecting with the given area.
     fn objects_in_area(&self, area: Aabb) -> Snapshot<'_>;
 
+    /// Returns read-only descriptions for all objects either completely
+    /// contained or intersecting with the given area.
+    fn objects_in_polygon(&self, area: &Polygon) -> Snapshot<'_>;
+
     /// Returns the amount of time that passed since the last call
     /// to the `step` function of [`Simulation`]
     fn elapsed_time_in_update(&self) -> Duration;


### PR DESCRIPTION
- Actually expose the collision checks added in 0.4.1 in `WorldInteractor`
- Improve performance by using references to `Polygon`s everywhere
